### PR TITLE
Add venv binaries to PATH in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ COPY ../ /app
 WORKDIR /app
 
 RUN python3 -m venv ./.venv
-RUN .venv/bin/pip install .
+ENV PATH="/app/.venv/bin:$PATH"
+
+RUN pip install .
+
 
 # Default command
 CMD ["/bin/bash"]


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->


Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Add .venv binaries to PATH in dockerfile. This allows us to use `pip` and `python` instead of `.venv/bin/python` inside the container.
