### PR TITLE
Fix: use custom sphinx build action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,10 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Compile sphinx docs
-        uses: ammaraskar/sphinx-action@master
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v5
         with:
-          docs-folder: ./docs
+          python-version: "3.12"
+      - run: |
+          python -m pip install --upgrade pip setuptools wheel virtualenv auditwheel pipx
+          test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install -e .[dev]
+
+      - name: Build docs
+        run: |
+          . .venv/bin/activate
+          cd docs
+          make html
+
       - name: Upload sphinx docs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes the big issue with using the external sphinx action: there is no possibility to set the python version, which interferes with importing the code for usage in autodoc.