### PR TITLE
92 fix errors different initialstate size

### DIFF
--- a/examples/attractor_detect1.py
+++ b/examples/attractor_detect1.py
@@ -1,7 +1,7 @@
 import bang
 
-#x_2 <- -(x_1 or x_2) and x_1
-#x_1 <- x_2
+# x_2 <- -(x_1 or x_2) and x_1
+# x_1 <- x_2
 n = 2
 nf = [1,1]
 nv = [1,1]
@@ -12,7 +12,7 @@ perturbation = 0.
 npNode = [0,1,2]
 n_parallel = 4
 
-pbn = bang.PBN(n,nf,nv,F,varFInt,cij,perturbation,npNode,n_parallel)
+pbn = bang.PBN(n, nf, nv, F, varFInt, cij, perturbation, npNode, n_parallel)
 
 initial_states = [[False, False],[True, False], [False, True], [True, True]]
 

--- a/examples/attractor_detect1.py
+++ b/examples/attractor_detect1.py
@@ -3,18 +3,18 @@ import bang
 # x_2 <- -(x_1 or x_2) and x_1
 # x_1 <- x_2
 n = 2
-nf = [1,1]
-nv = [1,1]
-F = [[False, True],[True, False]]
-varFInt = [[0],[1]]
-cij = [[1.],[1.]]
-perturbation = 0.
-npNode = [0,1,2]
+nf = [1, 1]
+nv = [1, 1]
+F = [[False, True], [True, False]]
+varFInt = [[0], [1]]
+cij = [[1.0], [1.0]]
+perturbation = 0.0
+npNode = [0, 1, 2]
 n_parallel = 4
 
 pbn = bang.PBN(n, nf, nv, F, varFInt, cij, perturbation, npNode, n_parallel)
 
-initial_states = [[False, False],[True, False], [False, True], [True, True]]
+initial_states = [[False, False], [True, False], [False, True], [True, True]]
 
 attractor, history = pbn.detect_attractor(initial_states)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # See https://setuptools.pypa.io/en/latest/userguide/quickstart.html for more project configuration options.
 name = "bang-gpu"
 readme = "README.md"
-version = "0.0.1-alpha.14"
+version = "0.0.1-alpha.16"
 
 authors = [
     { name = "Mikołaj Czarnecki", email = "mc448206@students.mimuw.edu.pl" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # See https://setuptools.pypa.io/en/latest/userguide/quickstart.html for more project configuration options.
 name = "bang-gpu"
 readme = "README.md"
-version = "0.0.1-alpha.16"
+version = "0.0.1-alpha.17"
 
 authors = [
     { name = "Mikołaj Czarnecki", email = "mc448206@students.mimuw.edu.pl" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 
 requires-python = ">=3.10"
-dependencies = ["python-libsbml", "numba==0.60.0", "numpy"]
+dependencies = ["python-libsbml", "numba-cuda==0.4.0", "numba==0.61.0", "numpy"]
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # See https://setuptools.pypa.io/en/latest/userguide/quickstart.html for more project configuration options.
 name = "bang-gpu"
 readme = "README.md"
-version = "0.0.1-alpha.13"
+version = "0.0.1-alpha.14"
 
 authors = [
     { name = "Mikołaj Czarnecki", email = "mc448206@students.mimuw.edu.pl" },

--- a/src/bang/__init__.py
+++ b/src/bang/__init__.py
@@ -1,7 +1,8 @@
-from .core import PBN, load_from_file
-from .graph.graph import get_blocks
 from numba import config
 
-config.CUDA_ENABLE_PYNVJITLINK = 1 # type: ignore
+from .core import PBN, load_from_file
+from .graph.graph import get_blocks
+
+config.CUDA_ENABLE_PYNVJITLINK = 1  # type: ignore
 
 __all__ = ["PBN", "load_from_file", "get_blocks"]

--- a/src/bang/__init__.py
+++ b/src/bang/__init__.py
@@ -1,4 +1,7 @@
 from .core import PBN, load_from_file
 from .graph.graph import get_blocks
+from numba import config
+
+config.CUDA_ENABLE_PYNVJITLINK = 1 # type: ignore
 
 __all__ = ["PBN", "load_from_file", "get_blocks"]

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -599,11 +599,11 @@ class PBN:
         :returns: List of states where attractors are coded as ints
         :rtype: np.ndarray
         """
-        
+
         self.set_states(initial_states, reset_history=True)
 
         history = self.get_last_state()
-        
+
         state_bytes = tuple(state.tobytes() for state in self.get_last_state())
         n_unique_states = len({state_bytes})
         last_n_unique_states = 0
@@ -614,7 +614,7 @@ class PBN:
             state_bytes = tuple(state.tobytes() for state in self.get_last_state())
             n_unique_states = len(set(state_bytes))
             history = np.hstack((history, self.get_last_state()))
-            
+
         state_bytes_set = list(set(state_bytes))
         ret_list = [np.frombuffer(state, dtype=np.int32)[0] for state in state_bytes_set]
         return (np.array(ret_list), history)
@@ -627,10 +627,10 @@ class PBN:
             print(trajectory)
             for i in range(len(trajectory) - 1):
                 if trajectory[i] in transition:
-                    if transition[trajectory[i]] != trajectory[i+1]:
+                    if transition[trajectory[i]] != trajectory[i + 1]:
                         raise ValueError("Two different states from the same state")
 
-                transition[trajectory[i]] = trajectory[i+1]
+                transition[trajectory[i]] = trajectory[i + 1]
 
         num_states = len(active_states)
 
@@ -638,16 +638,16 @@ class PBN:
 
         while num_states > 0:
             initial_state = active_states[0]
-            
-            rm_idx = np.where(active_states==initial_state)[0]
+
+            rm_idx = np.where(active_states == initial_state)[0]
             active_states = np.delete(active_states, rm_idx)
             attractor_states = [initial_state]
 
             curr_state = transition[initial_state]
             while curr_state != initial_state:
                 attractor_states.append(curr_state)
-                
-                rm_idx = np.where(active_states==curr_state)[0]
+
+                rm_idx = np.where(active_states == curr_state)[0]
                 active_states = np.delete(active_states, rm_idx)
 
                 curr_state = transition[curr_state]
@@ -656,8 +656,7 @@ class PBN:
             num_states = len(active_states)
 
         return attractors
-        
-                
+
 
 def load_sbml(path: str) -> tuple:
     return parseSBMLDocument(path)

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -190,7 +190,7 @@ class PBN:
 
     def set_states(self, states: List[List[bool]], reset_history: bool = False):
         """
-        Sets the initial states of the PBN. If the number of trajectories is different than the number of previous trajectories, 
+        Sets the initial states of the PBN. If the number of trajectories is different than the number of previous trajectories,
         the history will be pushed into `self.previous_simulations` and the active history will be reset.
 
         :param states: List of states to be set.
@@ -209,11 +209,17 @@ class PBN:
         else:
             if len(states) != self.history.shape[0]:
                 self.previous_simulations.append(self.history)
-                self.history = np.array(converted_states).reshape(self.n_parallel, 1, self.stateSize())
+                self.history = np.array(converted_states).reshape(
+                    self.n_parallel, 1, self.stateSize()
+                )
             else:
-                self.history = np.concatenate([self.history, np.array(converted_states).reshape(self.n_parallel, 1, self.stateSize())], axis=1)
-            
-
+                self.history = np.concatenate(
+                    [
+                        self.history,
+                        np.array(converted_states).reshape(self.n_parallel, 1, self.stateSize()),
+                    ],
+                    axis=1,
+                )
 
     def extraFCount(self) -> int:
         """
@@ -583,20 +589,15 @@ class PBN:
         else:
             self.history = run_history
 
-    def detect_attractor(self, initial_states):
+    def detect_attractor(self, initial_states: List[List[bool]]) -> np.ndarray:
         """
-            Detects all atractor states in PBN
+        Detects all atractor states in PBN
 
-            Parameters
-            ----------
+        :param initial_states: List of investigated states.
+        :type initial_states: List[List[bool]]
 
-            initial_states : List[List[Bool]]
-                List of investigated states. 
-            Returns
-            -------
-            attractor_states : np.array(int)
-                List of states where attractors are coded as ints
-
+        :returns: List of states where attractors are coded as ints
+        :rtype: np.ndarray
         """
         
         self.set_states(initial_states, reset_history=True)
@@ -607,7 +608,7 @@ class PBN:
         n_unique_states = len({state_bytes})
         last_n_unique_states = 0
 
-        while (n_unique_states != last_n_unique_states):
+        while n_unique_states != last_n_unique_states:
             self.simple_steps(1)
             last_n_unique_states = n_unique_states
             state_bytes = tuple(state.tobytes() for state in self.get_last_state())


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Fixes the errors caused when setting a PBN state with a different number of trajectories than previously.