### PR TITLE
102 workflow for official release to pypi

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
           path: dist/
 
   test-pypi:
-    name: Release
+    name: Release to Test PyPI
     runs-on: ubuntu-latest
     needs: [build]
     if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/v') }}
@@ -139,16 +139,38 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
-      # - name: Generate release notes
-      #   run: |
-      #     python scripts/release_notes.py > ${{ github.workspace }}-RELEASE_NOTES.md
+  official-pypi:
+    name: Release to PyPI
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+    environment:
+      name: pypi
+      url: https://pypi.org/project/bang-gpu/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      # - name: Publish GitHub release
-      #   uses: softprops/action-gh-release@v1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     body_path: ${{ github.workspace }}-RELEASE_NOTES.md
-      #     prerelease: ${{ contains(env.TAG, 'rc') }}
-      #     files: |
-      #       wheelhouse/*
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Prepare environment
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Download package distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts
+          path: ./dist/
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://pypi.org/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,4 +173,4 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://pypi.org/
+          repository-url: https://upload.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # See https://setuptools.pypa.io/en/latest/userguide/quickstart.html for more project configuration options.
 name = "bang-gpu"
 readme = "README.md"
-version = "0.0.1-alpha.29"
+version = "0.1.0"
 
 authors = [
     { name = "Mikołaj Czarnecki", email = "mc448206@students.mimuw.edu.pl" },


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
#### Closes #102 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
Add workflow step which releases to official PyPI. The step has a guard which prevents pre-releases from being pushed to PyPI (in semver, those are indicated by a dash "-" present in the version). This is based on the tag name, and therefore a pre-release could be published to PyPI if the version indicated by the tag name and the de facto package version do not match.
