### PR TITLE
116 add one at a time asynchronous simple step and simple_step improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # See https://setuptools.pypa.io/en/latest/userguide/quickstart.html for more project configuration options.
 name = "bang-gpu"
 readme = "README.md"
-version = "0.1.0"
+version = "0.2.0"
 
 authors = [
     { name = "Mikołaj Czarnecki", email = "mc448206@students.mimuw.edu.pl" },

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -656,7 +656,7 @@ class PBN:
             self.latest_state = self._perturb_state_by_actions(actions, self.latest_state)
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
-        self.gpu_initialState.copy_to_device(self.latest_state.reshape(self.n_parallel * self.stateSize()))
+        self.gpu_initialState = cuda.to_device(self.latest_state.reshape(self.n_parallel * self.stateSize()))
 
         states = create_xoroshiro128p_states(
             self.n_parallel, seed=numba.uint64(datetime.datetime.now().timestamp())

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -95,9 +95,10 @@ class PBN:
         self.previous_simulations: List[np.ndarray] = []
         self.save_history = save_history
 
-        self._allocate_arrays()
+        if cuda.is_available():
+            self._preallocate_arrays()
 
-    def _allocate_arrays(self):
+    def _preallocate_arrays(self):
         pbn_data = self.pbn_data_to_np_arrays(MAX_N_STEPS, self.save_history)
 
         (
@@ -320,7 +321,8 @@ class PBN:
                     axis=0,
                 )
 
-        self._allocate_arrays()
+        if cuda.is_available():
+            self._preallocate_arrays()
 
     def extraFCount(self) -> int:
         """

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -556,7 +556,7 @@ class PBN:
 
         if save_history:
             state_history = np.zeros(N * stateSize * (n_steps + 1), dtype=np.uint32)
-            state_history[:N * stateSize] = initial_state[:]
+            state_history[:N * stateSize] = initial_state.copy()[:]
 
         else:
             state_history = np.zeros(0, dtype=np.uint32)
@@ -914,7 +914,7 @@ class PBN:
             history = np.hstack((history, self.get_last_state()))
 
         state_bytes_set = list(set(state_bytes))
-        ret_list = [np.frombuffer(state, dtype=np.int32)[0] for state in state_bytes_set]
+        ret_list = [np.frombuffer(state, dtype=np.uint32)[0] for state in state_bytes_set]
         return (np.array(ret_list), history)
 
     def segment_attractor(self, attractor_states, history):

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -22,6 +22,7 @@ from bang.parsing.assa import load_assa
 from bang.parsing.sbml import parseSBMLDocument
 
 UpdateType = Literal["asynchronous_random_order", "asynchronous_one_random", "synchronous"]
+MAX_N_STEPS = 100000
 
 
 class PBN:
@@ -85,6 +86,52 @@ class PBN:
         self.latest_state: np.ndarray = np.zeros((n_parallel, self.stateSize()), dtype=np.uint32)
         self.previous_simulations: List[np.ndarray] = []
         self.save_history = save_history
+        self._allocate_arrays()
+
+    def _allocate_arrays(self):
+        pbn_data = self.pbn_data_to_np_arrays(MAX_N_STEPS, self.save_history)
+
+        (
+            state_history,
+            thread_num,
+            pow_num,
+            cum_function_count,
+            function_probabilities,
+            perturbation_rate,
+            cum_variable_count,
+            functions,
+            function_variables,
+            initial_state,
+            steps,
+            state_size,
+            extra_functions,
+            extra_functions_index,
+            cum_extra_functions,
+            extra_function_count,
+            extra_function_index_count,
+            perturbation_blacklist,
+            non_perturbed_count,
+        ) = pbn_data
+
+        self.gpu_cumNv = cuda.to_device(cum_variable_count)
+        self.gpu_F = cuda.to_device(functions)
+        self.gpu_varF = cuda.to_device(function_variables)
+        self.gpu_initialState = cuda.to_device(initial_state)
+        self.gpu_stateHistory = cuda.to_device(state_history)
+        self.gpu_threadNum = cuda.to_device(thread_num)
+        self.gpu_steps = cuda.to_device(steps)
+        self.gpu_stateSize = cuda.to_device(state_size)
+        self.gpu_extraF = cuda.to_device(extra_functions)
+        self.gpu_extraFIndex = cuda.to_device(extra_functions_index)
+        self.gpu_cumExtraF = cuda.to_device(cum_extra_functions)
+        self.gpu_extraFCount = cuda.to_device(extra_function_count)
+        self.gpu_extraFIndexCount = cuda.to_device(extra_function_index_count)
+        self.gpu_npNode = cuda.to_device(perturbation_blacklist)
+        self.gpu_npLength = cuda.to_device(non_perturbed_count)
+        self.gpu_cumCij = cuda.to_device(function_probabilities)
+        self.gpu_cumNf = cuda.to_device(cum_function_count)
+        self.gpu_perturbation_rate = cuda.to_device(perturbation_rate)
+        self.gpu_powNum = cuda.to_device(pow_num)
 
     def __str__(self):
         return f"PBN(n={self.n}, nf={self.nf}, nv={self.nv}, F={self.F}, varFInt={self.varFInt}, cij={self.cij}, perturbation={self.perturbation}, npNode={self.npNode})"
@@ -610,49 +657,6 @@ class PBN:
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
         # Convert PBN data to numpy arrays
-        pbn_data = self.pbn_data_to_np_arrays(n_steps, self.save_history)
-
-        (
-            state_history,
-            thread_num,
-            pow_num,
-            cum_function_count,
-            function_probabilities,
-            perturbation_rate,
-            cum_variable_count,
-            functions,
-            function_variables,
-            initial_state,
-            steps,
-            state_size,
-            extra_functions,
-            extra_functions_index,
-            cum_extra_functions,
-            extra_function_count,
-            extra_function_index_count,
-            perturbation_blacklist,
-            non_perturbed_count,
-        ) = pbn_data
-
-        gpu_cumNv = cuda.to_device(cum_variable_count)
-        gpu_F = cuda.to_device(functions)
-        gpu_varF = cuda.to_device(function_variables)
-        gpu_initialState = cuda.to_device(initial_state)
-        gpu_stateHistory = cuda.to_device(state_history)
-        gpu_threadNum = cuda.to_device(thread_num)
-        gpu_steps = cuda.to_device(steps)
-        gpu_stateSize = cuda.to_device(state_size)
-        gpu_extraF = cuda.to_device(extra_functions)
-        gpu_extraFIndex = cuda.to_device(extra_functions_index)
-        gpu_cumExtraF = cuda.to_device(cum_extra_functions)
-        gpu_extraFCount = cuda.to_device(extra_function_count)
-        gpu_extraFIndexCount = cuda.to_device(extra_function_index_count)
-        gpu_npNode = cuda.to_device(perturbation_blacklist)
-        gpu_npLength = cuda.to_device(non_perturbed_count)
-        gpu_cumCij = cuda.to_device(function_probabilities)
-        gpu_cumNf = cuda.to_device(cum_function_count)
-        gpu_perturbation_rate = cuda.to_device(perturbation_rate)
-        gpu_powNum = cuda.to_device(pow_num)
 
         states = create_xoroshiro128p_states(
             self.n_parallel, seed=numba.uint64(datetime.datetime.now().timestamp())
@@ -665,89 +669,89 @@ class PBN:
 
         if self.update_type == "asynchronous_one_random":
             kernel_converge_async_one_random[block, blockSize](  # type: ignore
-                gpu_stateHistory,
-                gpu_threadNum,
-                gpu_powNum,
-                gpu_cumNf,
-                gpu_cumCij,
+                self.gpu_stateHistory,
+                self.gpu_threadNum,
+                self.gpu_powNum,
+                self.gpu_cumNf,
+                self.gpu_cumCij,
                 states,
                 self.getN(),
-                gpu_perturbation_rate,
-                gpu_cumNv,
-                gpu_F,
-                gpu_varF,
-                gpu_initialState,
-                gpu_steps,
-                gpu_stateSize,
-                gpu_extraF,
-                gpu_extraFIndex,
-                gpu_cumExtraF,
-                gpu_extraFCount,
-                gpu_extraFIndexCount,
-                gpu_npLength,
-                gpu_npNode,
+                self.gpu_perturbation_rate,
+                self.gpu_cumNv,
+                self.gpu_F,
+                self.gpu_varF,
+                self.gpu_initialState,
+                self.gpu_steps,
+                self.gpu_stateSize,
+                self.gpu_extraF,
+                self.gpu_extraFIndex,
+                self.gpu_cumExtraF,
+                self.gpu_extraFCount,
+                self.gpu_extraFIndexCount,
+                self.gpu_npLength,
+                self.gpu_npNode,
                 self.save_history,
             )
         elif self.update_type == "asynchronous_random_order":
             kernel_converge_async_random_order[block, blockSize](  # type: ignore
-                gpu_stateHistory,
-                gpu_threadNum,
-                gpu_powNum,
-                gpu_cumNf,
-                gpu_cumCij,
+                self.gpu_stateHistory,
+                self.gpu_threadNum,
+                self.gpu_powNum,
+                self.gpu_cumNf,
+                self.gpu_cumCij,
                 states,
                 self.getN(),
-                gpu_perturbation_rate,
-                gpu_cumNv,
-                gpu_F,
-                gpu_varF,
-                gpu_initialState,
-                gpu_steps,
-                gpu_stateSize,
-                gpu_extraF,
-                gpu_extraFIndex,
-                gpu_cumExtraF,
-                gpu_extraFCount,
-                gpu_extraFIndexCount,
-                gpu_npLength,
-                gpu_npNode,
-                self.save_history,
+                self.gpu_perturbation_rate,
+                self.gpu_cumNv,
+                self.gpu_F,
+                self.gpu_varF,
+                self.gpu_initialState,
+                self.gpu_steps,
+                self.gpu_stateSize,
+                self.gpu_extraF,
+                self.gpu_extraFIndex,
+                self.gpu_cumExtraF,
+                self.gpu_extraFCount,
+                self.gpu_extraFIndexCount,
+                self.gpu_npLength,
+                self.gpu_npNode,
+                self.self.save_history,
             )
         elif self.update_type == "synchronous":
             kernel_converge_sync[block, blockSize](  # type: ignore
-                gpu_stateHistory,
-                gpu_threadNum,
-                gpu_powNum,
-                gpu_cumNf,
-                gpu_cumCij,
+                self.gpu_stateHistory,
+                self.gpu_threadNum,
+                self.gpu_powNum,
+                self.gpu_cumNf,
+                self.gpu_cumCij,
                 states,
                 self.getN(),
-                gpu_perturbation_rate,
-                gpu_cumNv,
-                gpu_F,
-                gpu_varF,
-                gpu_initialState,
-                gpu_steps,
-                gpu_stateSize,
-                gpu_extraF,
-                gpu_extraFIndex,
-                gpu_cumExtraF,
-                gpu_extraFCount,
-                gpu_extraFIndexCount,
-                gpu_npLength,
-                gpu_npNode,
+                self.gpu_perturbation_rate,
+                self.gpu_cumNv,
+                self.gpu_F,
+                self.gpu_varF,
+                self.gpu_initialState,
+                self.gpu_steps,
+                self.gpu_stateSize,
+                self.gpu_extraF,
+                self.gpu_extraFIndex,
+                self.gpu_cumExtraF,
+                self.gpu_extraFCount,
+                self.gpu_extraFIndexCount,
+                self.gpu_npLength,
+                self.gpu_npNode,
                 self.save_history,
             )
 
         cuda.synchronize()
 
-        last_state = gpu_initialState.copy_to_host()
-        run_history = gpu_stateHistory.copy_to_host()
+        last_state = self.gpu_initialState.copy_to_host()
+        run_history = self.gpu_stateHistory.copy_to_host()
 
         self.latest_state = last_state.reshape((self.n_parallel, self.stateSize()))
 
         if self.save_history:
-            run_history = run_history.reshape((n_steps + 1, self.n_parallel, self.stateSize()))
+            run_history = run_history.reshape((-1, self.n_parallel, self.stateSize()))[:n_steps+1, :, :]
 
             if self.history is not None:
                 self.history = np.concatenate([self.history, run_history[1:, :, :]], axis=0)

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -656,7 +656,7 @@ class PBN:
             self.latest_state = self._perturb_state_by_actions(actions, self.latest_state)
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
-        # Convert PBN data to numpy arrays
+        self.gpu_initialState[:] = self.latest_state
 
         states = create_xoroshiro128p_states(
             self.n_parallel, seed=numba.uint64(datetime.datetime.now().timestamp())
@@ -715,7 +715,7 @@ class PBN:
                 self.gpu_extraFIndexCount,
                 self.gpu_npLength,
                 self.gpu_npNode,
-                self.self.save_history,
+                self.save_history,
             )
         elif self.update_type == "synchronous":
             kernel_converge_sync[block, blockSize](  # type: ignore

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -982,7 +982,7 @@ class PBN:
         npNode.append(n)
 
         return PBN(
-            n, nf, nv, F, varFInt, cij, perturbation, npNode, self.n_parallel, update_type="asynchronous_random_order"
+            n, nf, nv, F, varFInt, cij, perturbation, npNode, self.n_parallel, update_type="synchronous"
         )
 
     # def segment_attractor(self, attractor_states, history):

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -656,7 +656,7 @@ class PBN:
             self.latest_state = self._perturb_state_by_actions(actions, self.latest_state)
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
-        self.gpu_initialState = cuda.to_device(self.latest_state.reshape(self.n_parallel * self.stateSize()))
+        new_gpuInitialState = cuda.to_device(self.latest_state.reshape(self.n_parallel * self.stateSize()))
 
         states = create_xoroshiro128p_states(
             self.n_parallel, seed=numba.uint64(datetime.datetime.now().timestamp())
@@ -682,7 +682,7 @@ class PBN:
                 self.gpu_cumNv,
                 self.gpu_F,
                 self.gpu_varF,
-                self.gpu_initialState,
+                new_gpuInitialState,
                 self.gpu_steps,
                 self.gpu_stateSize,
                 self.gpu_extraF,
@@ -707,7 +707,7 @@ class PBN:
                 self.gpu_cumNv,
                 self.gpu_F,
                 self.gpu_varF,
-                self.gpu_initialState,
+                new_gpuInitialState,
                 self.gpu_steps,
                 self.gpu_stateSize,
                 self.gpu_extraF,
@@ -732,7 +732,7 @@ class PBN:
                 self.gpu_cumNv,
                 self.gpu_F,
                 self.gpu_varF,
-                self.gpu_initialState,
+                new_gpuInitialState,
                 self.gpu_steps,
                 self.gpu_stateSize,
                 self.gpu_extraF,
@@ -749,8 +749,8 @@ class PBN:
 
         cuda.synchronize()
 
-        last_state = self.gpu_initialState.copy_to_host().copy()
-        run_history = self.gpu_stateHistory.copy_to_host().copy()
+        last_state = new_gpuInitialState.copy_to_host()
+        run_history = self.gpu_stateHistory.copy_to_host()
 
         self.latest_state = last_state.reshape((self.n_parallel, self.stateSize()))
 

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -656,7 +656,7 @@ class PBN:
             self.latest_state = self._perturb_state_by_actions(actions, self.latest_state)
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
-        self.gpu_initialState[:] = self.latest_state.reshape(self.n_parallel * self.stateSize())
+        self.gpu_initialState.copy_to_device(self.latest_state.reshape(self.n_parallel * self.stateSize()))
 
         states = create_xoroshiro128p_states(
             self.n_parallel, seed=numba.uint64(datetime.datetime.now().timestamp())

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -658,7 +658,8 @@ class PBN:
                 for _ in range(n_steps // MAX_N_STEPS):
                     self._execute_simple_steps(MAX_N_STEPS, actions)
             
-                self._execute_simple_steps(n_steps % MAX_N_STEPS, actions)
+                if n_steps % MAX_N_STEPS != 0:
+                    self._execute_simple_steps(n_steps % MAX_N_STEPS, actions)
             else: 
                 self._execute_simple_steps(n_steps, actions)
         else:

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -656,7 +656,7 @@ class PBN:
             self.latest_state = self._perturb_state_by_actions(actions, self.latest_state)
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
-        self.gpu_initialState[:] = self.latest_state
+        self.gpu_initialState[:] = self.latest_state.reshape(self.n_parallel * self.stateSize())
 
         states = create_xoroshiro128p_states(
             self.n_parallel, seed=numba.uint64(datetime.datetime.now().timestamp())

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -4,7 +4,6 @@ Module containing the PBN class and helpers.
 
 import datetime
 import math
-from enum import Enum
 from itertools import chain
 from typing import List, Literal
 
@@ -77,8 +76,8 @@ class PBN:
         self.npNode = list(sorted(npNode))
         self.n_parallel = n_parallel
         self.update_type = update_type
-        self.history: np.ndarray = np.zeros((1, n_parallel, self.stateSize()), dtype=np.int32)
-        self.latest_state: np.ndarray = np.zeros((n_parallel, self.stateSize()), dtype=np.int32)
+        self.history: np.ndarray = np.zeros((1, n_parallel, self.stateSize()), dtype=np.uint32)
+        self.latest_state: np.ndarray = np.zeros((n_parallel, self.stateSize()), dtype=np.uint32)
         self.previous_simulations: List[np.ndarray] = []
 
     def __str__(self):
@@ -215,7 +214,7 @@ class PBN:
         if len(bools) != node_count:
             raise ValueError("Number of bools must be equal to number of nodes")
 
-        integer_state = np.zeros((state_size), dtype=np.int32)
+        integer_state = np.zeros((state_size), dtype=np.uint32)
 
         for i in range(state_size)[::-1]:
             for bit in range((len(bools) - 32 * i) % 32):
@@ -479,8 +478,8 @@ class PBN:
         cij = list(chain.from_iterable(self.getCij()))
 
         cumCij = np.cumsum(cij, dtype=np.float32)
-        cumNv = np.cumsum([0] + nv, dtype=np.int32)
-        cumNf = np.cumsum([0] + nf, dtype=np.int32)
+        cumNv = np.cumsum([0] + nv, dtype=np.uint32)
+        cumNf = np.cumsum([0] + nf, dtype=np.uint32)
 
         perturbation = self.getPerturbation()
         npNode = self.getNpNode()
@@ -496,31 +495,31 @@ class PBN:
         N = self.n_parallel
 
         initial_state = (
-            np.zeros(N * stateSize, dtype=np.int32)
+            np.zeros(N * stateSize, dtype=np.uint32)
             if self.latest_state is None
             else self.latest_state
         )
         initial_state = initial_state.reshape(N * stateSize)
 
-        cum_variable_count = np.array(cumNv, dtype=np.int32)
-        functions = np.array(F, dtype=np.int32)
-        function_variables = np.array(varFInt, dtype=np.int32)
-        state_history = np.zeros(N * stateSize * (n_steps + 1), dtype=np.int32)
-        thread_num = np.array([N], dtype=np.int32)
-        steps = np.array([n_steps], dtype=np.int32)
-        state_size = np.array([stateSize], dtype=np.int32)
-        extra_functions = np.array(extraF, dtype=np.int32)
-        extra_functions_index = np.array(extraFIndex, dtype=np.int32)
-        cum_extra_functions = np.array(cumExtraF, dtype=np.int32)
-        extra_function_count = np.array([extraFCount], dtype=np.int32)
-        extra_function_index_count = np.array([extraFIndexCount], dtype=np.int32)
-        perturbation_blacklist = np.array(npNode, dtype=np.int32)
-        non_perturbed_count = np.array([len(npNode)], dtype=np.int32)
+        cum_variable_count = np.array(cumNv, dtype=np.uint32)
+        functions = np.array(F, dtype=np.uint32)
+        function_variables = np.array(varFInt, dtype=np.uint32)
+        state_history = np.zeros(N * stateSize * (n_steps + 1), dtype=np.uint32)
+        thread_num = np.array([N], dtype=np.uint32)
+        steps = np.array([n_steps], dtype=np.uint32)
+        state_size = np.array([stateSize], dtype=np.uint32)
+        extra_functions = np.array(extraF, dtype=np.uint32)
+        extra_functions_index = np.array(extraFIndex, dtype=np.uint32)
+        cum_extra_functions = np.array(cumExtraF, dtype=np.uint32)
+        extra_function_count = np.array([extraFCount], dtype=np.uint32)
+        extra_function_index_count = np.array([extraFIndexCount], dtype=np.uint32)
+        perturbation_blacklist = np.array(npNode, dtype=np.uint32)
+        non_perturbed_count = np.array([len(npNode)], dtype=np.uint32)
         function_probabilities = np.array(cumCij, dtype=np.float32)
-        cum_function_count = np.array(cumNf, dtype=np.int32)
+        cum_function_count = np.array(cumNf, dtype=np.uint32)
         perturbation_rate = np.array([perturbation], dtype=np.float32)
 
-        pow_num = np.zeros((2, 32), dtype=np.int32)
+        pow_num = np.zeros((2, 32), dtype=np.uint32)
         pow_num[1][0] = 1
         pow_num[0][0] = 0
 
@@ -724,6 +723,8 @@ class PBN:
                 gpu_npLength,
                 gpu_npNode,
             )
+
+        cuda.synchronize()
 
         last_state = gpu_initialState.copy_to_host()
         run_history = gpu_stateHistory.copy_to_host()

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -51,6 +51,10 @@ class PBN:
     :type latest_state: np.ndarray
     :param previous_simulations: List of previous simulations.
     :type previous_simulations: List[np.ndarray]
+    :param update_type: The type of update to use. The possible values are "asynchronous_one_random", "asynchronous_random_order" and "synchronous"
+    :type update_type: str
+    :param save_history: Whether to save the history of the PBN.
+    :type save_history: bool
     """
 
     def __init__(
@@ -65,6 +69,7 @@ class PBN:
         npNode: List[int],
         n_parallel: int = 512,
         update_type: UpdateType = "asynchronous_one_random",  ## TODO change to 0, synchronous shouldnt be default
+        save_history: bool = True
     ):
         self.n = n
         self.nf = nf
@@ -79,6 +84,7 @@ class PBN:
         self.history: np.ndarray = np.zeros((1, n_parallel, self.stateSize()), dtype=np.uint32)
         self.latest_state: np.ndarray = np.zeros((n_parallel, self.stateSize()), dtype=np.uint32)
         self.previous_simulations: List[np.ndarray] = []
+        self.save_history = save_history
 
     def __str__(self):
         return f"PBN(n={self.n}, nf={self.nf}, nv={self.nv}, F={self.F}, varFInt={self.varFInt}, cij={self.cij}, perturbation={self.perturbation}, npNode={self.npNode})"
@@ -470,7 +476,7 @@ class PBN:
 
         return new_varF, new_F
 
-    def pbn_data_to_np_arrays(self, n_steps: int):
+    def pbn_data_to_np_arrays(self, n_steps: int, save_history: bool = True):
         nf = self.getNf()
         nv = self.getNv()
         F = self.get_integer_f()
@@ -501,10 +507,14 @@ class PBN:
         )
         initial_state = initial_state.reshape(N * stateSize)
 
+        if save_history:
+            state_history = np.zeros(N * stateSize * (n_steps + 1), dtype=np.uint32)
+        else:
+            state_history = np.zeros(0, dtype=np.uint32)
+
         cum_variable_count = np.array(cumNv, dtype=np.uint32)
         functions = np.array(F, dtype=np.uint32)
         function_variables = np.array(varFInt, dtype=np.uint32)
-        state_history = np.zeros(N * stateSize * (n_steps + 1), dtype=np.uint32)
         thread_num = np.array([N], dtype=np.uint32)
         steps = np.array([n_steps], dtype=np.uint32)
         state_size = np.array([stateSize], dtype=np.uint32)
@@ -598,7 +608,7 @@ class PBN:
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
         # Convert PBN data to numpy arrays
-        pbn_data = self.pbn_data_to_np_arrays(n_steps)
+        pbn_data = self.pbn_data_to_np_arrays(n_steps, self.save_history)
 
         (
             state_history,
@@ -674,6 +684,7 @@ class PBN:
                 gpu_extraFIndexCount,
                 gpu_npLength,
                 gpu_npNode,
+                self.save_history,
             )
         elif self.update_type == "asynchronous_random_order":
             kernel_converge_async_random_order[block, blockSize](  # type: ignore
@@ -698,6 +709,7 @@ class PBN:
                 gpu_extraFIndexCount,
                 gpu_npLength,
                 gpu_npNode,
+                self.save_history,
             )
         elif self.update_type == "synchronous":
             kernel_converge_sync[block, blockSize](  # type: ignore
@@ -722,6 +734,7 @@ class PBN:
                 gpu_extraFIndexCount,
                 gpu_npLength,
                 gpu_npNode,
+                self.save_history,
             )
 
         cuda.synchronize()

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -663,8 +663,10 @@ class PBN:
         )
 
         block = self.n_parallel // 32
+
         if block == 0:
             block = 1
+
         blockSize = 32
 
         if self.update_type == "asynchronous_one_random":
@@ -742,11 +744,13 @@ class PBN:
                 self.gpu_npNode,
                 self.save_history,
             )
+        else:
+            raise ValueError(f"Unsupported update type: {self.update_type}")
 
         cuda.synchronize()
 
-        last_state = self.gpu_initialState.copy_to_host()
-        run_history = self.gpu_stateHistory.copy_to_host()
+        last_state = self.gpu_initialState.copy_to_host().copy()
+        run_history = self.gpu_stateHistory.copy_to_host().copy()
 
         self.latest_state = last_state.reshape((self.n_parallel, self.stateSize()))
 

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -51,7 +51,7 @@ class PBN:
     :type latest_state: np.ndarray
     :param previous_simulations: List of previous simulations.
     :type previous_simulations: List[np.ndarray]
-    :param update_type: The type of update to use. The possible values are "asynchronous_one_random", "asynchronous_random_order" and "synchronous"
+    :param update_type: The type of update to use. The possible values are "asynchronous_one_random", "asynchronous_random_order", "synchronous"
     :type update_type: str
     :param save_history: Whether to save the history of the PBN.
     :type save_history: bool
@@ -509,6 +509,8 @@ class PBN:
 
         if save_history:
             state_history = np.zeros(N * stateSize * (n_steps + 1), dtype=np.uint32)
+            state_history[:N * stateSize] = initial_state[:]
+
         else:
             state_history = np.zeros(0, dtype=np.uint32)
 
@@ -744,12 +746,13 @@ class PBN:
 
         self.latest_state = last_state.reshape((self.n_parallel, self.stateSize()))
 
-        run_history = run_history.reshape((n_steps + 1, self.n_parallel, self.stateSize()))
+        if self.save_history:
+            run_history = run_history.reshape((n_steps + 1, self.n_parallel, self.stateSize()))
 
-        if self.history is not None:
-            self.history = np.concatenate([self.history, run_history[1:, :, :]], axis=0)
-        else:
-            self.history = run_history
+            if self.history is not None:
+                self.history = np.concatenate([self.history, run_history[1:, :, :]], axis=0)
+            else:
+                self.history = run_history
 
     def simple_steps_cpu(self, n_steps: int, actions: npt.NDArray[np.uint] | None = None):
         """

--- a/src/bang/core/PBN.py
+++ b/src/bang/core/PBN.py
@@ -86,6 +86,7 @@ class PBN:
         self.latest_state: np.ndarray = np.zeros((n_parallel, self.stateSize()), dtype=np.uint32)
         self.previous_simulations: List[np.ndarray] = []
         self.save_history = save_history
+
         self._allocate_arrays()
 
     def _allocate_arrays(self):
@@ -93,7 +94,7 @@ class PBN:
 
         (
             state_history,
-            thread_num,
+            thread_num, # can vary between simple_steps executions
             pow_num,
             cum_function_count,
             function_probabilities,
@@ -101,8 +102,8 @@ class PBN:
             cum_variable_count,
             functions,
             function_variables,
-            initial_state,
-            steps,
+            initial_state, # usually varies between simple_steps executions
+            steps, # can vary between simple_steps executions
             state_size,
             extra_functions,
             extra_functions_index,
@@ -310,6 +311,8 @@ class PBN:
                     ],
                     axis=0,
                 )
+
+        self._allocate_arrays()
 
     def extraFCount(self) -> int:
         """
@@ -649,6 +652,29 @@ class PBN:
         :type actions: npt.NDArray[np.uint], optional
         :raises ValueError: If the initial state is not set before simulation.
         """
+        if cuda.is_available():
+            if self.save_history:
+                # batch simple_step executions to avoid allocating too much memory for history
+                for _ in range(n_steps // MAX_N_STEPS):
+                    self._execute_simple_steps(MAX_N_STEPS, actions)
+            
+                self._execute_simple_steps(n_steps % MAX_N_STEPS, actions)
+            else: 
+                self._execute_simple_steps(n_steps, actions)
+        else:
+            print("WARNING! CUDA is not available, falling back to CPU simulation")
+            self.simple_steps_cpu(n_steps, actions)
+
+    def _execute_simple_steps(self, n_steps: int, actions: npt.NDArray[np.uint] | None = None):
+        """
+        Simulates the PBN for a given number of steps.
+
+        :param n_steps: Number of steps to simulate.
+        :type n_steps: int
+        :param actions: Array of actions to be performed on the PBN. Defaults to None.
+        :type actions: npt.NDArray[np.uint], optional
+        :raises ValueError: If the initial state is not set before simulation.
+        """
         if self.latest_state is None or self.history is None:
             raise ValueError("Initial state must be set before simulation")
 
@@ -656,7 +682,8 @@ class PBN:
             self.latest_state = self._perturb_state_by_actions(actions, self.latest_state)
             self.history = np.concatenate([self.history, self.latest_state], axis=0)
 
-        new_gpuInitialState = cuda.to_device(self.latest_state.reshape(self.n_parallel * self.stateSize()))
+        self.gpu_initialState.copy_to_device(self.latest_state.reshape(self.n_parallel * self.stateSize()))
+        self.gpu_steps.copy_to_device(np.array([n_steps], dtype=np.uint32))
 
         states = create_xoroshiro128p_states(
             self.n_parallel, seed=numba.uint64(datetime.datetime.now().timestamp())
@@ -682,7 +709,7 @@ class PBN:
                 self.gpu_cumNv,
                 self.gpu_F,
                 self.gpu_varF,
-                new_gpuInitialState,
+                self.gpu_initialState,
                 self.gpu_steps,
                 self.gpu_stateSize,
                 self.gpu_extraF,
@@ -707,7 +734,7 @@ class PBN:
                 self.gpu_cumNv,
                 self.gpu_F,
                 self.gpu_varF,
-                new_gpuInitialState,
+                self.gpu_initialState,
                 self.gpu_steps,
                 self.gpu_stateSize,
                 self.gpu_extraF,
@@ -732,7 +759,7 @@ class PBN:
                 self.gpu_cumNv,
                 self.gpu_F,
                 self.gpu_varF,
-                new_gpuInitialState,
+                self.gpu_initialState,
                 self.gpu_steps,
                 self.gpu_stateSize,
                 self.gpu_extraF,
@@ -749,7 +776,7 @@ class PBN:
 
         cuda.synchronize()
 
-        last_state = new_gpuInitialState.copy_to_host()
+        last_state = self.gpu_initialState.copy_to_host()
         run_history = self.gpu_stateHistory.copy_to_host()
 
         self.latest_state = last_state.reshape((self.n_parallel, self.stateSize()))

--- a/src/bang/core/cpu/simulation.py
+++ b/src/bang/core/cpu/simulation.py
@@ -49,6 +49,7 @@ def update_node(
         shift_num = shift_num % 32
 
     element_f = element_f >> shift_num
+
     initial_state[index_state] ^= (-(element_f & 1) ^ initial_state_copy[index_state]) & (
         1 << (node_index - index_state * 32)
     )
@@ -116,8 +117,8 @@ def cpu_converge_sync(
     steps = steps[0]
 
     for idx in range(thread_num):
-        initial_state_copy = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
-        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
+        initial_state_copy = np.zeros(MAX_STATE_SIZE, dtype=np.uint32)
+        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.uint32)
         relative_index = idx * state_size
 
         # Initialize state
@@ -195,7 +196,7 @@ def cpu_converge_async_one_random(
     steps = steps[0]
 
     for idx in range(thread_num):
-        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
+        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.uint32)
         relative_index = idx * state_size
 
         # Initialize state
@@ -273,8 +274,8 @@ def cpu_converge_async_random_order(
     steps = steps[0]
 
     for idx in range(thread_num):
-        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
-        update_order = np.zeros(shape=(MAX_STATE_SIZE * 32,), dtype=np.int32)
+        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.uint32)
+        update_order = np.zeros(shape=(MAX_STATE_SIZE * 32,), dtype=np.uint32)
         relative_index = idx * state_size
 
         # Initialize state

--- a/src/bang/core/cpu/simulation.py
+++ b/src/bang/core/cpu/simulation.py
@@ -1,0 +1,333 @@
+import random
+import numpy as np
+
+def update_node(
+    node_index,
+    index_shift,
+    index_state,
+    rand,
+    cum_cij,
+    cum_nf,
+    cum_nv,
+    F,
+    extra_f_index,
+    extra_f,
+    cum_extra_f,
+    var_f,
+    pow_num,
+    initial_state_copy,
+    initial_state,
+):
+    relative_index = 0
+
+    # Choose function to update state
+    while rand > cum_cij[cum_nf[node_index] + relative_index]:
+        relative_index += 1
+
+    start = cum_nf[node_index] + relative_index
+    element_f = F[start]
+
+    # Process variables in function
+    start_var_f_index = cum_nv[start]
+    result_state_size = cum_nv[start + 1] - start_var_f_index
+    shift_num = 0
+
+    for ind in range(result_state_size):
+        relative_index = var_f[start_var_f_index + ind] // 32
+        state_fragment = initial_state_copy[relative_index]
+        if ((state_fragment >> (var_f[start_var_f_index + ind] % 32)) & 1) != 0:
+            shift_num += pow_num[1][ind]
+
+    # Handle extra functions if needed
+    if shift_num > 32:
+        tt = 0
+        while extra_f_index[tt] != start:
+            tt += 1
+        element_f = extra_f[cum_extra_f[tt] + ((shift_num - 32) // 32)]
+        shift_num = shift_num % 32
+
+    element_f = element_f >> shift_num
+    initial_state[index_state] ^= (-(element_f & 1) ^ initial_state_copy[index_state]) & (
+        1 << (node_index - index_state * 32)
+    )
+
+def perform_perturbation(
+    np_length,
+    np_node,
+    perturbation_rate,
+    initial_state_copy,
+):
+    start = 0
+    perturbation = False
+
+    for t in range(np_length[0]):
+        for node_index in range(start, np_node[t]):
+            if random.random() < perturbation_rate[0]:
+                perturbation = True
+                index_state = node_index // 32
+                initial_state_copy[index_state] ^= 1 << (node_index % 32)
+        start = np_node[t] + 1
+
+    return perturbation
+
+def update_initial_state(
+    thread_num,
+    state_history,
+    initial_state,
+    state_size,
+    idx,
+    step,
+    current_state,
+    initial_state_copy,
+):
+    relative_index = state_size * idx
+    for node_index in range(state_size):
+        initial_state_copy[node_index] = current_state[node_index]
+        initial_state[relative_index + node_index] = initial_state_copy[node_index]
+        state_history[
+            (step + 1) * thread_num + relative_index + node_index
+        ] = initial_state_copy[node_index]
+
+def cpu_converge_sync(
+    state_history,
+    thread_num,
+    pow_num,
+    cum_nf,
+    cum_cij,
+    node_num,
+    perturbation_rate,
+    cum_nv,
+    F,
+    var_f,
+    initial_state,
+    steps,
+    state_size,
+    extra_f,
+    extra_f_index,
+    cum_extra_f,
+    np_length,
+    np_node,
+):
+    state_size = state_size[0]
+    thread_num = thread_num[0]
+    steps = steps[0]
+
+    for idx in range(thread_num):
+        initial_state_copy = np.zeros(10, dtype=np.int32)
+        current_state = np.zeros(4, dtype=np.int32)
+        relative_index = idx * state_size
+
+        # Initialize state
+        for node_index in range(state_size):
+            initial_state_copy[node_index] = initial_state[relative_index + node_index]
+            current_state[node_index] = initial_state_copy[node_index]
+            state_history[relative_index + node_index] = current_state[node_index]
+
+        for step in range(steps):
+            perturbation = perform_perturbation(
+                np_length,
+                np_node,
+                perturbation_rate,
+                initial_state_copy,
+            )
+
+            if not perturbation:
+                for node_index in range(node_num):
+                    index_shift = 0
+                    index_state = node_index // 32
+                    rand = random.random()
+
+                    update_node(
+                        node_index,
+                        index_shift,
+                        index_state,
+                        rand,
+                        cum_cij,
+                        cum_nf,
+                        cum_nv,
+                        F,
+                        extra_f_index,
+                        extra_f,
+                        cum_extra_f,
+                        var_f,
+                        pow_num,
+                        initial_state_copy,
+                        current_state,
+                    )
+
+            update_initial_state(
+                thread_num,
+                state_history,
+                initial_state,
+                state_size,
+                idx,
+                step,
+                current_state,
+                initial_state_copy,
+            )
+
+def cpu_converge_async_one_random(
+    state_history,
+    thread_num,
+    pow_num,
+    cum_nf,
+    cum_cij,
+    node_num,
+    perturbation_rate,
+    cum_nv,
+    F,
+    var_f,
+    initial_state,
+    steps,
+    state_size,
+    extra_f,
+    extra_f_index,
+    cum_extra_f,
+    np_length,
+    np_node,
+):
+    state_size = state_size[0]
+    thread_num = thread_num[0]
+    steps = steps[0]
+
+    for idx in range(thread_num):
+        current_state = np.zeros(4, dtype=np.int32)
+        relative_index = idx * state_size
+
+        # Initialize state
+        for node_index in range(state_size):
+            current_state[node_index] = initial_state[relative_index + node_index]
+            state_history[relative_index + node_index] = current_state[node_index]
+
+        for step in range(steps):
+            perturbation = perform_perturbation(
+                np_length,
+                np_node,
+                perturbation_rate,
+                current_state,
+            )
+
+            if not perturbation:
+                node_index = random.randint(0, node_num - 1)
+                index_shift = node_index % 32
+                index_state = node_index // 32
+                rand = random.random()
+
+                update_node(
+                    node_index,
+                    index_shift,
+                    index_state,
+                    rand,
+                    cum_cij,
+                    cum_nf,
+                    cum_nv,
+                    F,
+                    extra_f_index,
+                    extra_f,
+                    cum_extra_f,
+                    var_f,
+                    pow_num,
+                    current_state,
+                    current_state,
+                )
+
+            update_initial_state(
+                thread_num,
+                state_history,
+                initial_state,
+                state_size,
+                idx,
+                step,
+                current_state,
+                current_state,
+            )
+
+
+def cpu_converge_async_random_order(
+    state_history,
+    thread_num,
+    pow_num,
+    cum_nf,
+    cum_cij,
+    node_num,
+    perturbation_rate,
+    cum_nv,
+    F,
+    var_f,
+    initial_state,
+    steps,
+    state_size,
+    extra_f,
+    extra_f_index,
+    cum_extra_f,
+    np_length,
+    np_node,
+):
+    state_size = state_size[0]
+    thread_num = thread_num[0]
+    steps = steps[0]
+
+    for idx in range(thread_num):
+        current_state = np.zeros(4, dtype=np.int32)
+        update_order = np.zeros(shape=(400,), dtype=np.int32)
+        relative_index = idx * state_size
+
+        # Initialize state
+        for node_index in range(state_size):
+            current_state[node_index] = initial_state[relative_index + node_index]
+            state_history[relative_index + node_index] = current_state[node_index]
+
+        for step in range(steps):
+            perturbation = perform_perturbation(
+                np_length,
+                np_node,
+                perturbation_rate,
+                current_state,
+            )
+
+            if not perturbation:
+                for i in range(node_num):
+                    update_order[i] = i
+
+                for i in range(node_num - 1, 0, -1):
+                    rand = random.randrange(0, 1)
+                    j = int(rand * (i + 1))
+
+                    update_order[i], update_order[j] = update_order[j], update_order[i]
+
+                for i in range(node_num):
+                    node_index = update_order[i]
+
+                    index_shift = node_index % 32
+                    index_state = node_index // 32
+
+                    rand = random.randint(0, 1)
+
+                    update_node(
+                        node_index,
+                        index_shift,
+                        index_state,
+                        rand,
+                        cum_cij,
+                        cum_nf,
+                        cum_nv,
+                        F,
+                        extra_f_index,
+                        extra_f,
+                        cum_extra_f,
+                        var_f,
+                        pow_num,
+                        current_state,
+                        current_state,
+                    )
+
+            update_initial_state(
+                thread_num,
+                state_history,
+                initial_state,
+                state_size,
+                idx,
+                step,
+                current_state,
+                current_state,
+            )

--- a/src/bang/core/cpu/simulation.py
+++ b/src/bang/core/cpu/simulation.py
@@ -1,7 +1,9 @@
 import random
+
 import numpy as np
 
 from bang.core.cuda.simulation import MAX_STATE_SIZE
+
 
 def update_node(
     node_index,
@@ -54,6 +56,7 @@ def update_node(
         1 << (node_index - index_state * 32)
     )
 
+
 def perform_perturbation(
     np_length,
     np_node,
@@ -73,6 +76,7 @@ def perform_perturbation(
 
     return perturbation
 
+
 def update_initial_state(
     thread_num,
     state_history,
@@ -87,9 +91,10 @@ def update_initial_state(
     for node_index in range(state_size):
         initial_state_copy[node_index] = current_state[node_index]
         initial_state[relative_index + node_index] = initial_state_copy[node_index]
-        state_history[
-            (step + 1) * thread_num + relative_index + node_index
-        ] = initial_state_copy[node_index]
+        state_history[(step + 1) * thread_num + relative_index + node_index] = initial_state_copy[
+            node_index
+        ]
+
 
 def cpu_converge_sync(
     state_history,
@@ -111,7 +116,7 @@ def cpu_converge_sync(
     np_length,
     np_node,
 ):
-    np.seterr(over='ignore')
+    np.seterr(over="ignore")
     state_size = state_size[0]
     thread_num = thread_num[0]
     steps = steps[0]
@@ -170,6 +175,7 @@ def cpu_converge_sync(
                 initial_state_copy,
             )
 
+
 def cpu_converge_async_one_random(
     state_history,
     thread_num,
@@ -190,7 +196,7 @@ def cpu_converge_async_one_random(
     np_length,
     np_node,
 ):
-    np.seterr(over='ignore')
+    np.seterr(over="ignore")
     state_size = state_size[0]
     thread_num = thread_num[0]
     steps = steps[0]
@@ -268,7 +274,7 @@ def cpu_converge_async_random_order(
     np_length,
     np_node,
 ):
-    np.seterr(over='ignore')
+    np.seterr(over="ignore")
     state_size = state_size[0]
     thread_num = thread_num[0]
     steps = steps[0]

--- a/src/bang/core/cpu/simulation.py
+++ b/src/bang/core/cpu/simulation.py
@@ -1,6 +1,8 @@
 import random
 import numpy as np
 
+from bang.core.cuda.simulation import MAX_STATE_SIZE
+
 def update_node(
     node_index,
     index_shift,
@@ -114,8 +116,8 @@ def cpu_converge_sync(
     steps = steps[0]
 
     for idx in range(thread_num):
-        initial_state_copy = np.zeros(10, dtype=np.int32)
-        current_state = np.zeros(4, dtype=np.int32)
+        initial_state_copy = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
+        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
         relative_index = idx * state_size
 
         # Initialize state
@@ -193,7 +195,7 @@ def cpu_converge_async_one_random(
     steps = steps[0]
 
     for idx in range(thread_num):
-        current_state = np.zeros(4, dtype=np.int32)
+        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
         relative_index = idx * state_size
 
         # Initialize state
@@ -271,8 +273,8 @@ def cpu_converge_async_random_order(
     steps = steps[0]
 
     for idx in range(thread_num):
-        current_state = np.zeros(4, dtype=np.int32)
-        update_order = np.zeros(shape=(400,), dtype=np.int32)
+        current_state = np.zeros(MAX_STATE_SIZE, dtype=np.int32)
+        update_order = np.zeros(shape=(MAX_STATE_SIZE * 32,), dtype=np.int32)
         relative_index = idx * state_size
 
         # Initialize state

--- a/src/bang/core/cpu/simulation.py
+++ b/src/bang/core/cpu/simulation.py
@@ -108,6 +108,7 @@ def cpu_converge_sync(
     np_length,
     np_node,
 ):
+    np.seterr(over='ignore')
     state_size = state_size[0]
     thread_num = thread_num[0]
     steps = steps[0]
@@ -186,6 +187,7 @@ def cpu_converge_async_one_random(
     np_length,
     np_node,
 ):
+    np.seterr(over='ignore')
     state_size = state_size[0]
     thread_num = thread_num[0]
     steps = steps[0]
@@ -263,6 +265,7 @@ def cpu_converge_async_random_order(
     np_length,
     np_node,
 ):
+    np.seterr(over='ignore')
     state_size = state_size[0]
     thread_num = thread_num[0]
     steps = steps[0]

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -4,6 +4,8 @@ import numba as nb
 from numba import cuda
 from numba.cuda.random import xoroshiro128p_uniform_float32
 
+# Maximum state size of 16 means we can hold 32 * 16 = 512 (size of int32 * MAX_STATE_SIZE)
+MAX_STATE_SIZE = 16
 
 @nb.jit
 def initialize_state(
@@ -158,8 +160,8 @@ def kernel_converge_sync(
     steps = gpu_steps[0]
     stateSize = gpu_stateSize[0]
 
-    initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.int32)
-    initialState = cuda.local.array(shape=(4,), dtype=nb.int32)
+    initialStateCopy = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
+    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
 
     relative_index = idx * stateSize
 
@@ -260,7 +262,7 @@ def kernel_converge_async_one_random(
     stateSize = gpu_stateSize[0]
 
     # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.int32)
-    initialState = cuda.local.array(shape=(4,), dtype=nb.int32)
+    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
 
     relative_index = idx * stateSize
 
@@ -350,8 +352,8 @@ def kernel_converge_async_random_order(
     stateSize = gpu_stateSize[0]
 
     # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.int32)
-    initialState = cuda.local.array(shape=(4,), dtype=nb.int32)
-    update_order = cuda.local.array(shape=(400,), dtype=nb.int32)
+    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
+    update_order = cuda.local.array(shape=(MAX_STATE_SIZE * 32,), dtype=nb.int32)
 
     relative_index = idx * stateSize
 

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -80,8 +80,7 @@ def update_node(
 
 
 @nb.jit
-def update_initial_state(
-    gpu_threadNum,
+def update_initial_state( gpu_threadNum,
     gpu_stateHistory,
     gpu_initialState,
     stateSize,
@@ -237,7 +236,97 @@ def kernel_converge_sync(
 
 
 @cuda.jit
-def kernel_converge_async(
+def kernel_converge_async_one_random(
+    gpu_stateHistory,
+    gpu_threadNum,
+    gpu_powNum,
+    gpu_cumNf,
+    gpu_cumCij,
+    states,
+    nodeNum,
+    gpu_perturbation_rate,
+    gpu_cumNv,
+    gpu_F,
+    gpu_varF,
+    gpu_initialState,
+    gpu_steps,
+    gpu_stateSize,
+    gpu_extraF,
+    gpu_extraFIndex,
+    gpu_cumExtraF,
+    gpu_extraFCount,
+    gpu_extraFIndexCount,
+    gpu_npLength,
+    gpu_npNode,
+):
+    idx = cuda.grid(1)
+
+    steps = gpu_steps[0]
+    stateSize = gpu_stateSize[0]
+
+    # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.int32)
+    initialState = cuda.local.array(shape=(4,), dtype=nb.int32)
+
+    relative_index = idx * stateSize
+
+    # get initial state of the trajectory this thread will simulate
+    # stateSize is the number of 32-bit integers needed to represent one state
+    for node_index in range(stateSize):
+        initialState[node_index] = gpu_initialState[relative_index + node_index]
+        gpu_stateHistory[relative_index + node_index] = initialState[node_index]
+
+    steps = gpu_steps[0]
+
+    for step in range(steps):
+        perturbation = False
+
+        perturbation = perform_perturbation(
+            gpu_npLength,
+            gpu_npNode,
+            gpu_perturbation_rate,
+            states,
+            idx,
+            initialState,
+        )
+
+        if not perturbation:
+            rand = xoroshiro128p_uniform_float32(states, idx)
+            node_index = int(rand * (nodeNum + 1))
+
+            index_shift = node_index % 32
+            index_state = node_index // 32
+
+            update_node(
+                node_index,
+                index_shift,
+                index_state,
+                rand,
+                gpu_cumCij,
+                gpu_cumNf,
+                gpu_cumNv,
+                gpu_F,
+                gpu_extraFIndex,
+                gpu_extraF,
+                gpu_cumExtraF,
+                gpu_varF,
+                gpu_powNum,
+                initialState,
+                initialState,
+            )
+
+        update_initial_state(
+            gpu_threadNum,
+            gpu_stateHistory,
+            gpu_initialState,
+            stateSize,
+            idx,
+            step,
+            initialState,
+            initialState,
+        )
+
+@cuda.jit
+def kernel_converge_async_random_order(
     gpu_stateHistory,
     gpu_threadNum,
     gpu_powNum,

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -291,7 +291,7 @@ def kernel_converge_async_one_random(
 
         if not perturbation:
             rand = xoroshiro128p_uniform_float32(states, idx)
-            node_index = int(rand * (nodeNum + 1))
+            node_index = int(rand * nodeNum)
 
             index_shift = node_index % 32
             index_state = node_index // 32

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -10,14 +10,13 @@ MAX_UPDATE_ORDER_SIZE = 512
 
 @nb.jit
 def initialize_state(
-    gpu_initialState, gpu_stateHistory, state_size, relative_index, initialStateCopy, initialState
+    gpu_initialState, state_size, relative_index, initialStateCopy, initialState
 ):
     # get initial state of the trajectory this thread will simulate
     # stateSize is the number of 32-bit integers needed to represent one state
     for node_index in range(state_size):
         initialStateCopy[node_index] = gpu_initialState[relative_index + node_index]
         initialState[node_index] = initialStateCopy[node_index]
-        gpu_stateHistory[relative_index + node_index] = initialState[node_index]
 
 
 @nb.jit
@@ -171,7 +170,6 @@ def kernel_converge_sync(
 
     initialize_state(
         gpu_initialState,
-        gpu_stateHistory,
         stateSize,
         relative_index,
         initialStateCopy,
@@ -276,7 +274,6 @@ def kernel_converge_async_one_random(
     # stateSize is the number of 32-bit integers needed to represent one state
     for node_index in range(stateSize):
         initialState[node_index] = gpu_initialState[relative_index + node_index]
-        gpu_stateHistory[relative_index + node_index] = initialState[node_index]
 
     steps = gpu_steps[0]
 
@@ -369,7 +366,6 @@ def kernel_converge_async_random_order(
     # stateSize is the number of 32-bit integers needed to represent one state
     for node_index in range(stateSize):
         initialState[node_index] = gpu_initialState[relative_index + node_index]
-        gpu_stateHistory[relative_index + node_index] = initialState[node_index]
 
     steps = gpu_steps[0]
 

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -197,11 +197,8 @@ def kernel_converge_sync(
             for node_index in range(nodeNum):
                 rand = xoroshiro128p_uniform_float32(states, idx)
 
-                index_shift = 0
-
-                if index_shift == 32:
-                    index_state += 1
-                    index_shift = 0
+                index_shift = node_index % 32
+                index_state = node_index // 32
 
                 update_node(
                     node_index,
@@ -220,8 +217,6 @@ def kernel_converge_sync(
                     initialStateCopy,
                     initialState,
                 )
-
-                index_shift += 1
 
         update_initial_state(
             gpu_threadNum,

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -6,6 +6,7 @@ from numba.cuda.random import xoroshiro128p_uniform_float32
 
 # Maximum state size of 16 means we can hold 32 * 16 = 512 (size of int32 * MAX_STATE_SIZE)
 MAX_STATE_SIZE = 16
+MAX_UPDATE_ORDER_SIZE = 512
 
 @nb.jit
 def initialize_state(
@@ -353,7 +354,7 @@ def kernel_converge_async_random_order(
 
     # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.int32)
     initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
-    update_order = cuda.local.array(shape=(MAX_STATE_SIZE * 32,), dtype=nb.int32)
+    update_order = cuda.local.array(shape=(MAX_UPDATE_ORDER_SIZE,), dtype=nb.int32)
 
     relative_index = idx * stateSize
 

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -4,7 +4,7 @@ import numba as nb
 from numba import cuda
 from numba.cuda.random import xoroshiro128p_uniform_float32
 
-# Maximum state size of 16 means we can hold 32 * 16 = 512 nodes (size of int32 * MAX_STATE_SIZE)
+# Maximum state size of 16 means we can hold 32 * 16 = 512 nodes (size of uint32 * MAX_STATE_SIZE)
 MAX_STATE_SIZE = 16
 MAX_UPDATE_ORDER_SIZE = 512
 
@@ -163,8 +163,8 @@ def kernel_converge_sync(
     steps = gpu_steps[0]
     stateSize = gpu_stateSize[0]
 
-    initialStateCopy = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
-    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
+    initialStateCopy = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.uint32)
+    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.uint32)
 
     relative_index = idx * stateSize
 
@@ -265,8 +265,8 @@ def kernel_converge_async_one_random(
     steps = gpu_steps[0]
     stateSize = gpu_stateSize[0]
 
-    # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.int32)
-    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
+    # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.uint32)
+    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.uint32)
 
     relative_index = idx * stateSize
 
@@ -356,9 +356,9 @@ def kernel_converge_async_random_order(
     steps = gpu_steps[0]
     stateSize = gpu_stateSize[0]
 
-    # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.int32)
-    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.int32)
-    update_order = cuda.local.array(shape=(MAX_UPDATE_ORDER_SIZE,), dtype=nb.int32)
+    # initialStateCopy = cuda.local.array(shape=(10,), dtype=nb.uint32)
+    initialState = cuda.local.array(shape=(MAX_STATE_SIZE,), dtype=nb.uint32)
+    update_order = cuda.local.array(shape=(MAX_UPDATE_ORDER_SIZE,), dtype=nb.uint32)
 
     relative_index = idx * stateSize
 

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -91,6 +91,7 @@ def update_initial_state( gpu_threadNum,
     step,
     initialState,
     initialStateCopy,
+    save_history,
 ):
     relative_index = stateSize * idx
 
@@ -98,9 +99,10 @@ def update_initial_state( gpu_threadNum,
         initialStateCopy[node_index] = initialState[node_index]
         gpu_initialState[relative_index + node_index] = initialStateCopy[node_index]
 
-        gpu_stateHistory[
-            (step + 1) * gpu_threadNum[0] + relative_index + node_index
-        ] = initialStateCopy[node_index]
+        if save_history:
+            gpu_stateHistory[
+                (step + 1) * gpu_threadNum[0] + relative_index + node_index
+            ] = initialStateCopy[node_index]
 
 
 @cuda.jit(device=True)
@@ -155,6 +157,7 @@ def kernel_converge_sync(
     gpu_extraFIndexCount,
     gpu_npLength,
     gpu_npNode,
+    save_history,
 ):
     idx = cuda.grid(1)
 
@@ -230,6 +233,7 @@ def kernel_converge_sync(
             step,
             initialState,
             initialStateCopy,
+            save_history,
         )
 
 
@@ -256,6 +260,7 @@ def kernel_converge_async_one_random(
     gpu_extraFIndexCount,
     gpu_npLength,
     gpu_npNode,
+    save_history,
 ):
     idx = cuda.grid(1)
 
@@ -321,6 +326,7 @@ def kernel_converge_async_one_random(
             step,
             initialState,
             initialState,
+            save_history,
         )
 
 @cuda.jit
@@ -346,6 +352,7 @@ def kernel_converge_async_random_order(
     gpu_extraFIndexCount,
     gpu_npLength,
     gpu_npNode,
+    save_history,
 ):
     idx = cuda.grid(1)
 
@@ -423,4 +430,5 @@ def kernel_converge_async_random_order(
             step,
             initialState,
             initialState,
+            save_history,
         )

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -8,10 +8,9 @@ from numba.cuda.random import xoroshiro128p_uniform_float32
 MAX_STATE_SIZE = 16
 MAX_UPDATE_ORDER_SIZE = 512
 
+
 @nb.jit
-def initialize_state(
-    gpu_initialState, state_size, relative_index, initialStateCopy, initialState
-):
+def initialize_state(gpu_initialState, state_size, relative_index, initialStateCopy, initialState):
     # get initial state of the trajectory this thread will simulate
     # stateSize is the number of 32-bit integers needed to represent one state
     for node_index in range(state_size):
@@ -82,7 +81,8 @@ def update_node(
 
 
 @nb.jit
-def update_initial_state( gpu_threadNum,
+def update_initial_state(
+    gpu_threadNum,
     gpu_stateHistory,
     gpu_initialState,
     stateSize,
@@ -325,6 +325,7 @@ def kernel_converge_async_one_random(
             initialState,
             save_history,
         )
+
 
 @cuda.jit
 def kernel_converge_async_random_order(

--- a/src/bang/core/cuda/simulation.py
+++ b/src/bang/core/cuda/simulation.py
@@ -4,7 +4,7 @@ import numba as nb
 from numba import cuda
 from numba.cuda.random import xoroshiro128p_uniform_float32
 
-# Maximum state size of 16 means we can hold 32 * 16 = 512 (size of int32 * MAX_STATE_SIZE)
+# Maximum state size of 16 means we can hold 32 * 16 = 512 nodes (size of int32 * MAX_STATE_SIZE)
 MAX_STATE_SIZE = 16
 MAX_UPDATE_ORDER_SIZE = 512
 

--- a/tests/test_cpu_save_history.py
+++ b/tests/test_cpu_save_history.py
@@ -1,0 +1,83 @@
+from bang.core.PBN import PBN
+
+
+def test_save_history_true():
+    pbn = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel=2,
+        update_type="synchronous",
+        save_history=True,
+    )
+    pbn.set_states([[True, False], [False, True]])
+
+    pbn.simple_steps_cpu(5)
+
+    assert pbn.history.shape == (7, 2, 1), pbn.history
+
+
+def test_save_history_no_set_state():
+    pbn = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel=2,
+        update_type="synchronous",
+    )
+
+    pbn.simple_steps_cpu(5)
+
+    assert pbn.history.shape == (6, 2, 1), pbn.history
+
+
+def test_save_history_false():
+    pbn = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel=2,
+        update_type="synchronous",
+        save_history=False,
+    )
+
+    pbn.simple_steps_cpu(5)
+
+    assert pbn.history.shape == (1, 2, 1), pbn.history
+
+
+def test_save_history_false_set_state():
+    pbn = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel=2,
+        update_type="synchronous",
+        save_history=False,
+    )
+
+    pbn.set_states([[True, False], [False, True]])
+
+    pbn.simple_steps_cpu(5)
+
+    assert pbn.history.shape == (2, 2, 1), pbn.history

--- a/tests/test_cpu_simple_step.py
+++ b/tests/test_cpu_simple_step.py
@@ -1,9 +1,22 @@
-import pytest
-from bang.core.PBN import PBN
 import numpy as np
+import pytest
+
+from bang.core.PBN import PBN
+
 
 def test_fixpoint_async_step():
-    pbn1 = PBN(2,[1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2],n_parallel=2, update_type="asynchronous_random_order")
+    pbn1 = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel=2,
+        update_type="asynchronous_random_order",
+    )
     pbn1.set_states([[True, False], [False, False]])
 
     pbn1.simple_steps_cpu(101)
@@ -12,7 +25,18 @@ def test_fixpoint_async_step():
 
 
 def test_fixpoint_sync_step():
-    pbn1 = PBN(2, [1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2],n_parallel=2, update_type="synchronous")
+    pbn1 = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel=2,
+        update_type="synchronous",
+    )
     pbn1.set_states([[True, False], [True, False]])
 
     pbn1.simple_steps_cpu(21)
@@ -60,16 +84,39 @@ def test_independent_pair_sync_step():
 
 @pytest.mark.parametrize("n_parallel", [16, 32, 64, 128, 256, 512])
 def test_large_n_parallel_sync(n_parallel):
-    pbn1 = PBN(2, [1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2], n_parallel, update_type="synchronous")
+    pbn1 = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel,
+        update_type="synchronous",
+    )
     pbn1.set_states([[False, False] for _ in range(n_parallel)])
 
     pbn1.simple_steps_cpu(21)
 
     assert np.array_equal([[3] for _ in range(n_parallel)], pbn1.latest_state), pbn1.latest_state
 
+
 @pytest.mark.parametrize("n_parallel", [16, 32, 64, 128, 256, 512])
 def test_large_n_parallel_async(n_parallel):
-    pbn1 = PBN(2, [1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2], n_parallel, update_type="asynchronous_random_order")
+    pbn1 = PBN(
+        2,
+        [1, 1],
+        [2, 2],
+        [[True, True, True, False], [True, False, True, True]],
+        [[0, 1], [0, 1]],
+        [[1.0], [1.0]],
+        0.0,
+        [2],
+        n_parallel,
+        update_type="asynchronous_random_order",
+    )
     pbn1.set_states([[False, False] for _ in range(n_parallel)])
 
     pbn1.simple_steps_cpu(21)

--- a/tests/test_cpu_simple_step.py
+++ b/tests/test_cpu_simple_step.py
@@ -1,0 +1,39 @@
+import pytest
+from bang.core.PBN import PBN
+import numpy as np
+
+def test_fixpoint_async_step():
+    pbn1 = PBN(2,[1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2],n_parallel=2, update_type="asynchronous_random_order")
+    pbn1.set_states([[True, False], [False, False]])
+
+    pbn1.simple_steps_cpu(101)
+
+    assert np.array_equal([[1], [3]], pbn1.latest_state), pbn1.latest_state
+
+
+def test_fixpoint_sync_step():
+    pbn1 = PBN(2, [1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2],n_parallel=2, update_type="synchronous")
+    pbn1.set_states([[True, False], [True, False]])
+
+    pbn1.simple_steps_cpu(21)
+
+    assert np.array_equal([[1], [1]], pbn1.latest_state), pbn1.latest_state
+
+
+@pytest.mark.parametrize("n_parallel", [16, 32, 64, 128, 256, 512])
+def test_large_n_parallel_sync(n_parallel):
+    pbn1 = PBN(2, [1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2], n_parallel, update_type="synchronous")
+    pbn1.set_states([[False, False] for _ in range(n_parallel)])
+
+    pbn1.simple_steps_cpu(21)
+
+    assert np.array_equal([[3] for _ in range(n_parallel)], pbn1.latest_state), pbn1.latest_state
+
+@pytest.mark.parametrize("n_parallel", [16, 32, 64, 128, 256, 512])
+def test_large_n_parallel_async(n_parallel):
+    pbn1 = PBN(2, [1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2], n_parallel, update_type="asynchronous_random_order")
+    pbn1.set_states([[False, False] for _ in range(n_parallel)])
+
+    pbn1.simple_steps_cpu(21)
+
+    assert np.array_equal([[3] for _ in range(n_parallel)], pbn1.latest_state), pbn1.latest_state

--- a/tests/test_cpu_simple_step.py
+++ b/tests/test_cpu_simple_step.py
@@ -20,6 +20,44 @@ def test_fixpoint_sync_step():
     assert np.array_equal([[1], [1]], pbn1.latest_state), pbn1.latest_state
 
 
+def test_independent_pair_sync_step():
+    test_n_nodes = 4
+
+    pbn_num_func = [1 for _ in range(test_n_nodes)]
+    pbn_num_var = [2 for _ in range(test_n_nodes)]
+    pbn_probs = [[1.0] for _ in range(test_n_nodes)]
+    pbn_var_indexes = [[(i // 2) * 2, (i // 2) * 2 + 1] for i in range(test_n_nodes)]
+    functions_1 = [[True, True, True, False] for _ in range(test_n_nodes // 2)]
+    functions_2 = [[True, False, True, True] for _ in range(test_n_nodes // 2)]
+    pbn_functions: list[list[bool]] = []
+
+    for a, b in zip(functions_1, functions_2):
+        pbn_functions.append(a)
+        pbn_functions.append(b)
+
+    pbn2 = PBN(
+        test_n_nodes,
+        pbn_num_func,
+        pbn_num_var,
+        pbn_functions,
+        pbn_var_indexes,
+        pbn_probs,
+        0.0,
+        [test_n_nodes],
+        n_parallel=1,
+        update_type="synchronous",
+    )
+
+    pbn2.simple_steps_cpu(1)
+    assert np.array_equal([[15]], pbn2.latest_state)
+
+    pbn2.simple_steps_cpu(1)
+    assert np.array_equal([[10]], pbn2.latest_state)
+
+    pbn2.simple_steps_cpu(1)
+    assert np.array_equal([[15]], pbn2.latest_state)
+
+
 @pytest.mark.parametrize("n_parallel", [16, 32, 64, 128, 256, 512])
 def test_large_n_parallel_sync(n_parallel):
     pbn1 = PBN(2, [1,1],[2,2],[[True, True, True, False],[True, False, True, True]], [[0,1],[0,1]],[[1.],[1.]],0.,[2], n_parallel, update_type="synchronous")

--- a/tests/test_cpu_simple_step_large_n.py
+++ b/tests/test_cpu_simple_step_large_n.py
@@ -1,0 +1,94 @@
+from bang import PBN
+import pytest
+import numpy as np
+
+large_testdata = [
+    (32, 1),
+    (64, 2),
+    (128, 4),
+    (256, 8),
+    (512, 16),
+]
+
+@pytest.mark.parametrize("test_n_nodes, test_n_states", large_testdata)
+def test_simple_step_large_nodeset(test_n_nodes, test_n_states):
+    pbn_num_func = [1 for _ in range(test_n_nodes)]
+    pbn_num_var = [2 for _ in range(test_n_nodes)]
+    pbn_probs = [[1.0] for _ in range(test_n_nodes)]
+    pbn_var_indexes = [[i // 2, i // 2 + 1] for i in range(test_n_nodes)]
+    functions_1 = [[True, True, True, False] for _ in range(test_n_nodes // 2)]
+    functions_2 = [[True, False, True, True] for _ in range(test_n_nodes // 2)]
+    pbn_functions: list[list[bool]] = []
+
+    for a, b in zip(functions_1, functions_2):
+        pbn_functions.append(a)
+        pbn_functions.append(b)
+
+    pbn1 = PBN(
+        test_n_nodes,
+        pbn_num_func,
+        pbn_num_var,
+        pbn_functions,
+        pbn_var_indexes,
+        pbn_probs,
+        0.0,
+        [test_n_nodes],
+        n_parallel=1,
+        update_type="synchronous",
+    )
+
+    pbn1.simple_steps_cpu(1)
+
+    last_state = pbn1.get_last_state()
+
+    expected = [[2**32 - 1 for _ in range(test_n_states)]]
+
+    assert np.array_equal(expected, last_state), last_state
+
+
+missing_pair_testdata = [
+    (30, 1),
+    (62, 2),
+    (126, 4),
+    (254, 8),
+    (510, 16),
+]
+
+
+@pytest.mark.parametrize("test_n_nodes, test_n_states", missing_pair_testdata)
+def test_update_state_large_missing_pair(test_n_nodes, test_n_states):
+    # Here we test if updates are correct if the total is not a multiple of 32
+    # This way we see if the first state will be less that 2**32 - 1
+
+    pbn_num_func = [1 for _ in range(test_n_nodes)]
+    pbn_num_var = [2 for _ in range(test_n_nodes)]
+    pbn_probs = [[1.0] for _ in range(test_n_nodes)]
+    pbn_var_indexes = [[i // 2, i // 2 + 1] for i in range(test_n_nodes)]
+    functions_1 = [[True, True, True, False] for _ in range(test_n_nodes // 2)]
+    functions_2 = [[True, False, True, True] for _ in range(test_n_nodes // 2)]
+    pbn_functions: list[list[bool]] = []
+
+    for a, b in zip(functions_1, functions_2):
+        pbn_functions.append(a)
+        pbn_functions.append(b)
+
+    pbn1 = PBN(
+        test_n_nodes,
+        pbn_num_func,
+        pbn_num_var,
+        pbn_functions,
+        pbn_var_indexes,
+        pbn_probs,
+        0.0,
+        [test_n_nodes],
+        n_parallel=1,
+        update_type="synchronous",
+    )
+
+    pbn1.simple_steps_cpu(1)
+
+    last_state = pbn1.get_last_state()
+
+    expected = [[2**32 - 1 for _ in range(test_n_states - 1)] + [2**30 - 1]]
+
+    assert np.array_equal(last_state, expected), last_state

--- a/tests/test_cpu_simple_step_large_n.py
+++ b/tests/test_cpu_simple_step_large_n.py
@@ -1,6 +1,7 @@
-from bang import PBN
-import pytest
 import numpy as np
+import pytest
+
+from bang import PBN
 
 large_testdata = [
     (32, 1),
@@ -9,6 +10,7 @@ large_testdata = [
     (256, 8),
     (512, 16),
 ]
+
 
 @pytest.mark.parametrize("test_n_nodes, test_n_states", large_testdata)
 def test_simple_step_large_nodeset(test_n_nodes, test_n_states):

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -258,7 +258,7 @@ def test_update_node_permutations():
         0.0,
         [2],
         n_parallel=1,
-        update_type_int=0,
+        update_type="asynchronous_random_order",
     )
 
     prepared_data = pbn1.pbn_data_to_np_arrays(1)


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
# Closes #116 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Introduce asynchronous_one_random update type
- Add CPU-based functions analogical to the 3 update types present on the GPU
- Add multiple unit tests for CPU "kernels" which use shared core logic - this core logic is the update_node function which is reused across CPU and GPU variants of the functions
- Fix bugs related to overflows due to typing arrays as int32 instead of uint32
- Fix a bug related to index_shift calculation in GPU kernels which resulted in erroneous data being saved to history
- Add a flag `save_history` to PBN which controls whether the execution history of states during simulation is saved
- Add batched execution of up to a (large) constant number of steps at a time to reduce memory load on the GPU. Executions of a number of steps larger than the constant are split into multiple kernel calls.
